### PR TITLE
chore(samples): add source order request samples

### DIFF
--- a/samples/cancel-source-order.py
+++ b/samples/cancel-source-order.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+
+__author__ = "HPInc."
+
+#
+# DELETE ME!
+# Import parent directory to the sys.path to be able to load OneflowSDK
+#
+
+import sys, os
+
+current = os.path.dirname(os.path.realpath(__file__))
+parent = os.path.dirname(current)
+sys.path.append(parent)
+
+#
+# Cancel source order request logic
+#
+
+import json, os
+from OneflowSDK import OneflowSDK
+
+# credentials and endpoint
+token = os.environ["ONEFLOW_TOKEN"]
+secret = os.environ["ONEFLOW_SECRET"]
+endpoint = "https://pro-api.oneflowcloud.com"
+
+# OneflowSDK instance
+client = OneflowSDK(endpoint, token, secret)
+
+# specific api call
+source_name = "CHANGE_ME_YOUR_SOURCE_NAME"
+source_order_id = "CHANGE_ME_YOUR_SOURCE_ORDER_ID"
+
+api_path = "/api/order/{source_name}/{source_order_id}/cancel".format(source_name=source_name, source_order_id=source_order_id)
+
+# make the PUT request to the endpoint
+r = client.request("PUT", api_path)
+
+# output the results
+print("result", r)

--- a/samples/get-source-order.py
+++ b/samples/get-source-order.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+
+__author__ = "HPInc."
+
+#
+# DELETE ME!
+# Import parent directory to the sys.path to be able to load OneflowSDK
+#
+
+import sys, os
+
+current = os.path.dirname(os.path.realpath(__file__))
+parent = os.path.dirname(current)
+sys.path.append(parent)
+
+#
+# Get source order request logic
+#
+
+import json, os
+from OneflowSDK import OneflowSDK
+
+# credentials and endpoint
+token = os.environ["ONEFLOW_TOKEN"]
+secret = os.environ["ONEFLOW_SECRET"]
+endpoint = "https://pro-api.oneflowcloud.com"
+
+# OneflowSDK instance
+client = OneflowSDK(endpoint, token, secret)
+
+# specific api call
+source_order_id = "CHANGE_ME_YOUR_SOURCE_ORDER_ID"
+
+api_path = "/api/order/bysourceid/{source_order_id}".format(source_order_id=source_order_id)
+
+# make the GET request to the endpoint
+r = client.request("GET", api_path)
+
+# output the results
+print("result", r)


### PR DESCRIPTION
This PR addresses the request from @Stirl (https://github.com/HPInc/oneflow-sdk-python/commit/4642b95665f648da8155cbe6555898497b2720a8#commitcomment-147933505).

This PR adds two more examples of API requests using this SDK where we have parameters on the request path:
- How to get an order using the source order ID
- How to cancel an order using the source name and the source order ID 